### PR TITLE
Add support for cc_on_error query parameter

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -43,8 +43,10 @@ class Publisher < Sinatra::Base
 
     # keep some important vars
     process_payload(@payload)
+    # query parameter specifying additional users or teams to ping in the error issue.
+    @cc_on_error = params[:cc_on_error].split(",").map{|user_or_team| "@" + user_or_team} if params[:cc_on_error]
 
-    Resque.enqueue(BuildJob, @committer, @sha, @originating_hostname, @originating_repo)
+    Resque.enqueue(BuildJob, @committer, @sha, @originating_hostname, @originating_repo, @cc_on_error)
   end
 
   helpers Helpers

--- a/lib/build_job.rb
+++ b/lib/build_job.rb
@@ -5,12 +5,13 @@ require_relative 'cloner'
 class BuildJob
   @queue = :default
 
-  def self.perform(committers, sha, originating_hostname, originating_repo)
+  def self.perform(committers, sha, originating_hostname, originating_repo, cc_on_error)
     cloner = Cloner.new({
       :committers            => committers,
       :sha                   => sha,
       :originating_hostname  => originating_hostname,
-      :originating_repo      => originating_repo
+      :originating_repo      => originating_repo,
+      :cc_on_error           => cc_on_error
     })
 
     cloner.clone

--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -9,10 +9,11 @@ class Cloner
     :sha                  => nil,
     :originating_hostname => GITHUB_DOMAIN,
     :originating_repo     => nil,
+    :cc_on_error          => [],
     :git                  => nil
   }
 
-  attr_accessor :tmpdir, :committers, :sha, :originating_hostname, :originating_repo
+  attr_accessor :tmpdir, :committers, :sha, :originating_hostname, :originating_repo, :cc_on_error
 
   def initialize(options)
     logger.level = Logger::WARN if ENV['RACK_ENV'] == 'test'
@@ -112,14 +113,13 @@ Hey, I'm really sorry about this, but there was some kind of error when I tried 
 You'll have to resolve this problem manually, I'm afraid.
 
 ![I'm sorry](http://pa1.narvii.com/5910/2c8b457dd08a3ff9e09680168960288a6882991c_hq.gif)
-
     MARKDOWN
 
 
-    if committers.any?
+    if committers.any? or cc_on_error.any?
       body << <<-MARKDOWN
 
-/cc #{committers.join(' ')}
+/cc #{committers.join(' ')} #{cc_on_error.join(' ')}
       MARKDOWN
     end
 

--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -5,7 +5,7 @@ class Cloner
 
   DEFAULTS = {
     :tmpdir               => nil,
-    :committers           => nil,
+    :committers           => [],
     :sha                  => nil,
     :originating_hostname => GITHUB_DOMAIN,
     :originating_repo     => nil,
@@ -116,7 +116,7 @@ You'll have to resolve this problem manually, I'm afraid.
     MARKDOWN
 
 
-    if committers
+    if committers.any?
       body << <<-MARKDOWN
 
 /cc #{committers.join(' ')}

--- a/lib/cloner.rb
+++ b/lib/cloner.rb
@@ -101,15 +101,28 @@ class Cloner
   end
 
   def report_error(command, command_output)
-    body = "Hey, I'm really sorry about this, but there was some kind of error "
-    body << "when I tried to publish the last time, from #{sha}:\n"
-    body << "\n```\n"
-    body << "#{command}\n"
-    body << command_output
-    body << "\n```\n"
-    body << "You'll have to resolve this problem manually, I'm afraid.\n"
-    body << "![I'm sorry](http://pa1.narvii.com/5910/2c8b457dd08a3ff9e09680168960288a6882991c_hq.gif)"
-    body << "\n\n /cc #{committers.join(' ')}" unless committers.nil?
+    body = <<-MARKDOWN
+Hey, I'm really sorry about this, but there was some kind of error when I tried to publish the last time, from #{sha}:
+
+```
+#{command}
+#{command_output}
+```
+
+You'll have to resolve this problem manually, I'm afraid.
+
+![I'm sorry](http://pa1.narvii.com/5910/2c8b457dd08a3ff9e09680168960288a6882991c_hq.gif)
+
+    MARKDOWN
+
+
+    if committers
+      body << <<-MARKDOWN
+
+/cc #{committers.join(' ')}
+      MARKDOWN
+    end
+
     client.create_issue originating_repo, 'Error detected', body
   end
 

--- a/spec/cloner_spec.rb
+++ b/spec/cloner_spec.rb
@@ -60,7 +60,7 @@ describe 'Cloner' do
 
   it "reports errors" do
     stub = stub_request(:post, "https://api.github.com/repos/gjtorikian/originating_repo/issues").
-         with(:body => "{\"labels\":[],\"title\":\"Error detected\",\"body\":\"Hey, I'm really sorry about this, but there was some kind of error when I tried to publish the last time, from :\\n\\n```\\necho foo bar\\nfoo\\nMerge error\\nbar\\n```\\nYou'll have to resolve this problem manually, I'm afraid.\\n![I'm sorry](http://pa1.narvii.com/5910/2c8b457dd08a3ff9e09680168960288a6882991c_hq.gif)\"}",
+         with(:body => "{\"labels\":[],\"title\":\"Error detected\",\"body\":\"Hey, I'm really sorry about this, but there was some kind of error when I tried to publish the last time, from :\\n\\n```\\necho foo bar\\nfoo\\nMerge error\\nbar\\n```\\n\\nYou'll have to resolve this problem manually, I'm afraid.\\n\\n![I'm sorry](http://pa1.narvii.com/5910/2c8b457dd08a3ff9e09680168960288a6882991c_hq.gif)\\n\"}",
               :headers => {'Accept'=>'application/vnd.github.v3+json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Octokit Ruby Gem 4.2.0'}).
          to_return(:status => 204, :body => "", :headers => {})
 

--- a/spec/cloner_spec.rb
+++ b/spec/cloner_spec.rb
@@ -70,4 +70,47 @@ describe 'Cloner' do
     cloner.report_error(command, output)
     expect(stub).to have_been_requested
   end
+
+  it "reports errors with committers cc'd" do
+    cloner.committers = ['@nuclearsandwich', '@gjtorikian']
+    stub = stub_request(:post, "https://api.github.com/repos/gjtorikian/originating_repo/issues").
+         with(:body => "{\"labels\":[],\"title\":\"Error detected\",\"body\":\"Hey, I'm really sorry about this, but there was some kind of error when I tried to publish the last time, from :\\n\\n```\\necho foo bar\\nfoo\\nMerge error\\nbar\\n```\\n\\nYou'll have to resolve this problem manually, I'm afraid.\\n\\n![I'm sorry](http://pa1.narvii.com/5910/2c8b457dd08a3ff9e09680168960288a6882991c_hq.gif)\\n\\n/cc @nuclearsandwich @gjtorikian \\n\"}",
+              :headers => {'Accept'=>'application/vnd.github.v3+json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Octokit Ruby Gem 4.2.0'}).
+         to_return(:status => 204, :body => "", :headers => {})
+
+    command = 'echo foo bar'
+    output = "foo\nMerge error\nbar"
+
+    cloner.report_error(command, output)
+    expect(stub).to have_been_requested
+  end
+
+  it "cc's teams that want to know about errors" do
+    cloner.cc_on_error = ['@github/support-tools']
+    stub = stub_request(:post, "https://api.github.com/repos/gjtorikian/originating_repo/issues").
+         with(:body => "{\"labels\":[],\"title\":\"Error detected\",\"body\":\"Hey, I'm really sorry about this, but there was some kind of error when I tried to publish the last time, from :\\n\\n```\\necho foo bar\\nfoo\\nMerge error\\nbar\\n```\\n\\nYou'll have to resolve this problem manually, I'm afraid.\\n\\n![I'm sorry](http://pa1.narvii.com/5910/2c8b457dd08a3ff9e09680168960288a6882991c_hq.gif)\\n\\n/cc  @github/support-tools\\n\"}",
+              :headers => {'Accept'=>'application/vnd.github.v3+json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Octokit Ruby Gem 4.2.0'}).
+         to_return(:status => 204, :body => "", :headers => {})
+
+    command = 'echo foo bar'
+    output = "foo\nMerge error\nbar"
+
+    cloner.report_error(command, output)
+    expect(stub).to have_been_requested
+  end
+
+  it "cc's teams and committers together" do
+    cloner.committers = ['@nuclearsandwich', '@gjtorikian']
+    cloner.cc_on_error = ['@github/support-tools', '@nuclearsandwich']
+    stub = stub_request(:post, "https://api.github.com/repos/gjtorikian/originating_repo/issues").
+         with(:body => "{\"labels\":[],\"title\":\"Error detected\",\"body\":\"Hey, I'm really sorry about this, but there was some kind of error when I tried to publish the last time, from :\\n\\n```\\necho foo bar\\nfoo\\nMerge error\\nbar\\n```\\n\\nYou'll have to resolve this problem manually, I'm afraid.\\n\\n![I'm sorry](http://pa1.narvii.com/5910/2c8b457dd08a3ff9e09680168960288a6882991c_hq.gif)\\n\\n/cc @nuclearsandwich @gjtorikian @github/support-tools @nuclearsandwich\\n\"}",
+              :headers => {'Accept'=>'application/vnd.github.v3+json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Octokit Ruby Gem 4.2.0'}).
+         to_return(:status => 204, :body => "", :headers => {})
+
+    command = 'echo foo bar'
+    output = "foo\nMerge error\nbar"
+
+    cloner.report_error(command, output)
+    expect(stub).to have_been_requested
+  end
 end


### PR DESCRIPTION
cc_on_error allows individual repositories to specify via query parameter specific teams or individuals who should be cc'd in all cases in the event of an error. I think a query parameter is the way to go
since it allows the value to be changed by anyone with admin access to the repository being published rather than someone with code or environment variable control access to publisher itself.

/cc @gjtorikian @lachlanhardy @lynnwallenstein